### PR TITLE
API等の外部ネットワークを使用したテストのCI上での実行を２つのワークフローに分けるようにした

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: 2
+version: 2.1
 
-jobs:
-  test:
+executors:
+  rails:
     docker:
       - image: circleci/ruby:2.5.1-node-browsers
         environment:
@@ -13,8 +13,10 @@ jobs:
           MYSQL_DATABASE: sst_test
           TZ: /usr/share/zoneinfo/Asia/Tokyo
     working_directory: ~/repo
+
+commands:
+  bundle_install:
     steps:
-      - checkout
       - restore_cache:
           name: bundle installの結果をrestore
           keys: 
@@ -27,26 +29,48 @@ jobs:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: rubocopを実行(Lint)
-          command: bundle exec rubocop
-      - run:
-          name: brakemanを実行(セキュリティチェック)
-          command: bundle exec brakeman -4 -A -w 1 -z
+  db_setup: 
+    steps:
       - run:
           name: データベースの起動を待機
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
       - run:
           name: データベースのセットアップ
           command: bundle exec rake db:schema:load
+
+jobs:
+  test:
+    executor: rails
+    steps:
+      - checkout
+      - bundle_install
+      - run:
+          name: rubocopを実行(Lint)
+          command: bundle exec rubocop
+      - run:
+          name: brakemanを実行(セキュリティチェック)
+          command: bundle exec brakeman -4 -A -w 1 -z
+      - db_setup
       - run: 
           name: テストの実行
           command: bundle exec rspec -fd --tag ~@use_external_network:true
       - store_artifacts:
           path: coverage
+  use_external_network_test: #外部APIを使用したテスト
+    executor: rails
+    steps:
+      - checkout
+      - bundle_install
+      - db_setup
+      - run: 
+          name: テストの実行
+          command: bundle exec rspec -fd --tag @use_external_network:true
 
 workflows:
   version: 2
-  workflows:
+  default_workflow:
     jobs:
       - test
+  use_external_network_test_workflow:
+    jobs:
+      - use_external_network_test


### PR DESCRIPTION
API等の外部ネットワークを使用したテストのCI上での実行を２つのワークフローに分けるようにした

外部ネットワークを使用すると処理が遅くなるので